### PR TITLE
Chore: cross-publish to quay.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,23 +9,23 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.14
-      -
-        name: Login to Docker Registry
+      - name: Login to quay.io
+        run: |
+          echo "${{ secrets.QUAY_IO_PASSWORD }}" | \
+          docker login quay.io -u "${{ secrets.QUAY_IO_USERNAME }}" --password-stdin
+      - name: Login to GitHub Docker Registry
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | \
           docker login docker.pkg.github.com -u docker --password-stdin
-      -
-        name: Run GoReleaser
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,6 +31,10 @@ dockers:
   - "docker.pkg.github.com/hostwithquantum/github-org-sync-action/github-org-sync:v{{ .Major }}"
   - "docker.pkg.github.com/hostwithquantum/github-org-sync-action/github-org-sync:v{{ .Major }}.{{ .Minor }}"
   - "docker.pkg.github.com/hostwithquantum/github-org-sync-action/github-org-sync:latest"
+  - "quay.io/hostwithquantum/github-org-sync:v{{ .Tag }}"
+  - "quay.io/hostwithquantum/github-org-sync:v{{ .Major }}"
+  - "quay.io/hostwithquantum/github-org-sync:v{{ .Major }}.{{ .Minor }}"
+  - "quay.io/hostwithquantum/github-org-sync:latest"
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ All releases are done using the amazing `goreleaser` in a release workflow in th
 You may download a release for Mac, Linux or Windows here:
  - https://github.com/hostwithquantum/github-org-sync-action/releases
 
-To use the Docker image, please follow this link:
+To use the Docker image, please follow one of these links:
+ - https://quay.io/repository/hostwithquantum/github-org-sync?tab=tags
  - https://github.com/hostwithquantum/github-org-sync-action/packages
 
 Otherwise: `make dev` to build a snapshot.

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'docker://docker.pkg.github.com/hostwithquantum/github-org-sync-action/github-org-sync:latest'
+  image: 'docker://quay.io/hostwithquantum/github-org-sync:latest'
   env:
     GITHUB_USER: ${{ inputs.github-user }}
     GITHUB_EMAIL: ${{ inputs.github-email }}


### PR DESCRIPTION
 - attempt to fix that GitHub's docker registry does not integration with Actions